### PR TITLE
Don't make `docs` by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ TARGET      = vm
 ASM         = nasm
 ASMFLAGS    = -fbin -I$(TESTDIR)/
 
-all: $(BUILDDIR) $(OBJDIR) $(BUILDDIR)/$(TARGET) $(OBJECTS) $(TESTS) $(TESTTARGETS) docs
+all: $(BUILDDIR) $(OBJDIR) $(BUILDDIR)/$(TARGET) $(OBJECTS) $(TESTS) $(TESTTARGETS)
  
 $(BUILDDIR)/$(TARGET): $(OBJECTS) 
 	$(CC) $(LDFLAGS) $(OBJECTS) -o $@


### PR DESCRIPTION
This requires doxygen to be installed, which seems to be an overkill.